### PR TITLE
Feature/docker/scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20-alpine as build
 
-RUN apk add --no-cache build-base tzdata
+RUN apk add --no-cache build-base tzdata ca-certificates
 
 WORKDIR /go/src/aesir
 COPY go.mod go.sum main.go ./
@@ -9,15 +9,18 @@ RUN go mod download
 COPY .env Makefile wire.go wire_gen.go ./
 COPY src/ ./src
 RUN go build -ldflags='-s -w' -o out/aesir .
-RUN ldd /go/src/aesir/out/aesir | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /go/src/aesir/out%
+RUN ldd /go/src/aesir/out/aesir | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /go/src/aesir/out/%
 RUN ln -s ld-musl-x86_64.so.1 /go/src/aesir/out/lib/libc.musl-x86_64.so.1
 
 FROM scratch as prod
 
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+ENV TZ=Asia/Seoul
+
 COPY public/ ./public
 COPY --from=build /go/src/aesir/.env ./
 COPY --from=build /go/src/aesir/out/ ./
-COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=Asia/Seoul
+
 #USER 65534
 ENTRYPOINT ["/aesir"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.20 as build
+FROM golang:1.20-alpine as build
+
+RUN apk add --no-cache build-base tzdata
 
 WORKDIR /go/src/aesir
 COPY go.mod go.sum main.go ./
@@ -6,14 +8,16 @@ RUN go mod download
 
 COPY .env Makefile wire.go wire_gen.go ./
 COPY src/ ./src
-RUN make build
+RUN go build -ldflags='-s -w' -o out/aesir .
+RUN ldd /go/src/aesir/out/aesir | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /go/src/aesir/out%
+RUN ln -s ld-musl-x86_64.so.1 /go/src/aesir/out/lib/libc.musl-x86_64.so.1
 
-FROM golang:1.20 as prod
-
-WORKDIR /go/src/aesir
+FROM scratch as prod
 
 COPY public/ ./public
 COPY --from=build /go/src/aesir/.env ./
 COPY --from=build /go/src/aesir/out/ ./
-
-ENTRYPOINT ["./aesir"]
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+ENV TZ=Asia/Seoul
+#USER 65534
+ENTRYPOINT ["/aesir"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.20-alpine as build
 
-RUN apk add --no-cache build-base tzdata ca-certificates
+RUN apk add --no-cache go gcc g++
+RUN apk add --no-cache tzdata ca-certificates
 
 WORKDIR /go/src/aesir
 COPY go.mod go.sum main.go ./
@@ -8,11 +9,11 @@ RUN go mod download
 
 COPY .env Makefile wire.go wire_gen.go ./
 COPY src/ ./src
-RUN go build -ldflags='-s -w' -o out/aesir .
-RUN ldd /go/src/aesir/out/aesir | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /go/src/aesir/out/%
-RUN ln -s ld-musl-x86_64.so.1 /go/src/aesir/out/lib/libc.musl-x86_64.so.1
+RUN CGO_ENABLED=1 GOOS=linux go build -o out/aesir .
+#RUN ldd /go/src/aesir/out/aesir | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /go/src/aesir/out/%
+#RUN ln -s ld-musl-x86_64.so.1 /go/src/aesir/out/lib/libc.musl-x86_64.so.1
 
-FROM scratch as prod
+FROM alpine:edge as prod
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo


### PR DESCRIPTION
# Description
- build stage에서 명령어를 분리하여 도커 빌드 캐시 활용하도록 변경
- 최종 빌드 결과물이 alpine:edge 이미지를 사용하도록 변경
![Screenshot 2023-07-30 at 2 31 31 PM](https://github.com/psyho-pw/aesir/assets/21997820/53f6c5ea-0e7d-42e6-81d0-1ec69096d4aa)
